### PR TITLE
add cell.setEdited and table.setCellEdited features

### DIFF
--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -47,6 +47,7 @@ export default class Edit extends Module{
 		
 		this.registerComponentFunction("cell", "isEdited", this.cellIsEdited.bind(this));
 		this.registerComponentFunction("cell", "clearEdited", this.clearEdited.bind(this));
+		this.registerComponentFunction("cell", "setEdited", this.setEdited.bind(this));
 		this.registerComponentFunction("cell", "edit", this.editCell.bind(this));
 		this.registerComponentFunction("cell", "cancelEdit", this.cellCancelEdit.bind(this));
 		
@@ -170,6 +171,16 @@ export default class Edit extends Module{
 		
 		cells.forEach((cell) => {
 			this.table.modules.edit.clearEdited(cell._getSelf());
+		});
+	}
+
+	setCellEdited(cells){
+		if(!Array.isArray(cells)){
+			cells = [cells];
+		}
+		
+		cells.forEach((cell) => {
+			this.table.modules.edit.setEdited(cell._getSelf());
 		});
 	}
 	
@@ -810,6 +821,22 @@ export default class Edit extends Module{
 		
 		if(editIndex > -1){
 			this.editedCells.splice(editIndex, 1);
+		}
+	}
+
+	setEdited(cell){
+		var editIndex;
+		
+		if(cell.modules.edit && cell.modules.edit.edited){
+			cell.modules.edit.edited = true;
+			
+			this.dispatch("edit-success", cell);
+		}
+		
+		editIndex = this.editedCells.indexOf(cell);
+		
+		if(editIndex === -1){
+			this.editedCells.push(cell);
 		}
 	}
 }


### PR DESCRIPTION
Implements feature request https://github.com/olifolkerd/tabulator/issues/4443

This adds a new function to the cell component `setEdited` and the table component `setCellEdited` that allows a developer to programmatically mark a cell as edited. The rationale is in the linked issue - basically we want to be able to control this flag and also provide a mirror function to `clearEdited`. 

This has been tested by manually calling the method, checking the `isEdited()` method to see if it is true, and finally by calling `table.getEditedCells()` to see if the cell shows up in that array.