### PR TITLE
Add “ignorecase” parameter to unique validator for case-insensitive comparison

### DIFF
--- a/src/js/modules/Validate/defaults/validators.js
+++ b/src/js/modules/Validate/defaults/validators.js
@@ -125,22 +125,17 @@ export default {
 		if(value === "" || value === null || typeof value === "undefined"){
 			return true;
 		}
-		var unique = true;
 
 		var cellData = cell.getData();
 		var column = cell.getColumn()._getSelf();
 
-		this.table.rowManager.rows.forEach(function(row){
+		return !this.table.rowManager.rows.some(function(row){
 			var data = row.getData();
 
 			if(data !== cellData){
-				if(value == column.getFieldValue(data)){
-					unique = false;
-				}
+				return value == column.getFieldValue(data);
 			}
 		});
-
-		return unique;
 	},
 
 	//must have a value

--- a/src/js/modules/Validate/defaults/validators.js
+++ b/src/js/modules/Validate/defaults/validators.js
@@ -126,6 +126,10 @@ export default {
 			return true;
 		}
 
+		var equals = parameters === "ignorecase"
+			? (x, y) => x.toLowerCase() == y.toLowerCase()
+			: (x, y) => x == y;
+
 		var cellData = cell.getData();
 		var column = cell.getColumn()._getSelf();
 
@@ -133,7 +137,7 @@ export default {
 			var data = row.getData();
 
 			if(data !== cellData){
-				return value == column.getFieldValue(data);
+				return equals(value, column.getFieldValue(data));
 			}
 		});
 	},


### PR DESCRIPTION
Hi,

I propose these two small changes to the unique validator.

The implementation of the “ignorecase” parameter uses the crude-ish `toLowerCase()` technique. One may prefer a locale-aware solution using [localeCompare()](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare), or offer several options using different parameters.

Thank you for your consideration!