### PR TITLE
fix: col-resize-handle height bug

### DIFF
--- a/src/js/modules/ResizeColumns/ResizeColumns.js
+++ b/src/js/modules/ResizeColumns/ResizeColumns.js
@@ -174,6 +174,8 @@ export default class ResizeColumns extends Module{
 				handle.style.position = "sticky";
 				handle.style[column.modules.frozen.position] = this.frozenColumnOffset(column);
 			}
+
+			handle.style.height = component.row?.heightStyled;
 			
 			config.handleEl = handle;
 			


### PR DESCRIPTION
issue[#4544](https://github.com/olifolkerd/tabulator/issues/4544)

After cell editing, "col-resize-handle" will be re-rendered and lose its height. When create the "col-resize-handle" element, set the height to cell.row.heightStyle. This should be no problem.