### PR TITLE
fix topCalc has blank line bug when group exists

### DIFF
--- a/src/js/modules/ColumnCalcs/ColumnCalcs.js
+++ b/src/js/modules/ColumnCalcs/ColumnCalcs.js
@@ -253,6 +253,7 @@ export default class ColumnCalcs extends Module{
 		
 		if(this.topInitialized){
 			this.topInitialized = false;
+			this.topElement.parentNode.removeChild(this.topElement.previousSibling);
 			this.topElement.parentNode.removeChild(this.topElement);
 			changed = true;
 		}


### PR DESCRIPTION
issue #4540

A "br" was inserted in "initializeTopRow", but it was not deleted in "removeCalcs".
![image](https://github.com/user-attachments/assets/a92a51fd-843d-474a-9fbb-8d911099a7a7)
