### PR TITLE
Fix editor closing when clicking input with selectRange enabled.

### DIFF
--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -738,11 +738,17 @@ export default class Edit extends Module{
 						//trigger onRendered Callback
 						rendered();
 						
-						//prevent editing from triggering rowClick event
+						//prevent editing from triggering rowClick and range events
 						var children = element.children;
 						
 						for (var i = 0; i < children.length; i++) {
 							children[i].addEventListener("click", function(e){
+								e.stopPropagation();
+							});
+							children[i].addEventListener("mousedown", function(e){
+								e.stopPropagation();
+							});
+							children[i].addEventListener("mouseup", function(e){
 								e.stopPropagation();
 							});
 						}


### PR DESCRIPTION
As mentioned in #4563, clicking the input element while editing, e.g. to place the caret, closes the editor when `selectRange` is enabled.

To fix this, this PR prevents propagation of `mousedown` and `mouseup` events for the editor elements, in addition to the already prevented `click` event.

Ranges can still be selected outside the currently edited cell.