### PR TITLE
Fix(Edit module): fix for #4716

### DIFF
--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -626,12 +626,11 @@ export default class Edit extends Module{
 		cellEditor, component, params;
 
 		//prevent editing if another cell is refusing to leave focus (eg. validation fail)
-		
 		if(this.currentCell){
-			if(!this.invalidEdit && this.currentCell !== cell){
+			if(this.invalidEdit && this.currentCell !== cell){
 				this.cancelEdit();
+				return;
 			}
-			return;
 		}
 		
 		//handle successful value change


### PR DESCRIPTION
This code fixes the case of 2 (or more) adjacent cells with an editor set (see issue #4716): when navigating with the TAB key the second (actually all the "even") editor wasn't activated