### PR TITLE
perf: streamline cell content generation

### DIFF
--- a/src/js/core/cell/Cell.js
+++ b/src/js/core/cell/Cell.js
@@ -98,22 +98,18 @@ export default class Cell extends CoreFeature{
 
 	//generate cell contents
 	_generateContents(){
-		var val;
-
-		val = this.chain("cell-format", this, null, () => {
-			return this.element.innerHTML = this.value;
+		const val = this.chain("cell-format", this, null, () => {
+			return this.value;
 		});
 
 		switch(typeof val){
 			case "object":
 				if(val instanceof Node){
-
 					//clear previous cell contents
-					while(this.element.firstChild) this.element.removeChild(this.element.firstChild);
-
+					this._clearCellContent();
 					this.element.appendChild(val);
 				}else{
-					this.element.innerHTML = "";
+					this._clearCellContent();
 
 					if(val != null){
 						console.warn("Format Error - Formatter has returned a type of object, the only valid formatter object return is an instance of Node, the formatter returned:", val);
@@ -121,11 +117,15 @@ export default class Cell extends CoreFeature{
 				}
 				break;
 			case "undefined":
-				this.element.innerHTML = "";
+				this._clearCellContent();
 				break;
 			default:
 				this.element.innerHTML = val;
 		}
+	}
+
+	_clearCellContent(){
+		while(this.element.firstChild) this.element.removeChild(this.element.firstChild);
 	}
 
 	cellRendered(){


### PR DESCRIPTION
### What
Two changes to `Cell._generateContents`:
- Write `innerHTML` once instead of twice — the fallback set `innerHTML = value` and returned it, then the `switch` `default` wrote it again.
- Clear cell content with a `removeChild` loop (`_clearCellContent()`) instead of `innerHTML = ""`.

### Behaviour
Unchanged — Format tests pass. The common formatted-string path (`default: innerHTML = val`) is untouched. No new browser requirements.

### Performance (isolated, 250k renders; jsdom, directional)
- render, no formatter (2× → 1× innerHTML) 2971 → 1492 ms (~2.0×); clear cell (`innerHTML=""` → `removeChild`) 1257 → 489 ms (~2.6×).

### Grid impact
Negligible — with the Format module present the common path is unchanged, so full-grid render is unaffected (headless Chromium, virtual renderer). The win applies to no-Format builds and cell-clear paths. Baseline `upstream/master` @ `9539446`.
