### PR TITLE
Change for Chrome DevTools to stop raising issues for pagination fields

### DIFF
--- a/src/js/modules/Page/Page.js
+++ b/src/js/modules/Page/Page.js
@@ -265,6 +265,7 @@ export default class Page extends Module{
 		if(this.table.options.paginationSizeSelector){
 			this.pageSizeSelect = document.createElement("select");
 			this.pageSizeSelect.classList.add("tabulator-page-size");
+			this.pageSizeSelect.setAttribute("id", this.table.element.id + "-page-select");
 		}
 	}
 	
@@ -407,6 +408,7 @@ export default class Page extends Module{
 			
 			if(this.pageSizeSelect){
 				pageSelectLabel = document.createElement("label");
+				pageSelectLabel.setAttribute("for", this.table.element.id + "-page-select");
 				
 				this.langBind("pagination|page_size", (value) => {
 					this.pageSizeSelect.setAttribute("aria-label", value);


### PR DESCRIPTION
Currently, Chrome DevTools raises issues for tabulator tables with page size selection due to a lack of relation between the select input and it's label:
<img width="1021" height="459" alt="image" src="https://github.com/user-attachments/assets/9be1cc21-e552-4859-930d-63a352e7bbf1" />

According to MDN, the recommended aproach is to always link the form and label elements with a "for" property, mainly due to accessibility:
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/label

Even if it's debatable whether DevTools should be raising these issues, trying to keep the browser issues list empty and following the best practices for accessibility, I propose this PR as a low priority minor annoyance fix that doesn't affect functionality.