### PR TITLE
fix: eliminate O(n) lag on rectangular selection in large tables

### DIFF
--- a/src/js/core/RowManager.js
+++ b/src/js/core/RowManager.js
@@ -194,8 +194,15 @@ export default class RowManager extends CoreFeature{
 	}
 	
 	getRowFromPosition(position){
-		return this.getDisplayRows().find((row) => {
-			return row.type === "row" && row.getPosition() === position && row.isDisplayed();
+		var displayRows = this.getDisplayRows();
+		var row = displayRows[position - 1];
+
+		if (row && row.type === "row" && row.getPosition() === position) {
+			return row;
+		}
+
+		return displayRows.find((row) => {
+			return row.type === "row" && row.getPosition() === position;
 		});
 	}
 	

--- a/src/js/modules/SelectRange/SelectRange.js
+++ b/src/js/modules/SelectRange/SelectRange.js
@@ -23,6 +23,10 @@ export default class SelectRange extends Module {
 		this.maxRanges = 0;
 		this.activeRange = false;
 		this.blockKeydown = false;
+		this._rafId = null;
+		this._pendingCell = null;
+		this._pendingColumn = null;
+		this._tableRowsCache = null;
 		
 		this.keyDownEvent = this._handleKeyDown.bind(this);
 		this.mouseUpEvent = this._handleMouseUp.bind(this);
@@ -232,6 +236,11 @@ export default class SelectRange extends Module {
 	_handleMouseUp(e){
 		this.mousedown = false;
 		document.removeEventListener("mouseup", this.mouseUpEvent);
+
+		if (this._rafId) {
+			cancelAnimationFrame(this._rafId);
+			this._rafId = null;
+		}
 	}
 	
 	_handleKeyDown(e) {
@@ -340,11 +349,20 @@ export default class SelectRange extends Module {
 		if (column === this.rowHeader || !this.mousedown || this.selecting === 'all') {
 			return;
 		}
-		
-		this.activeRange.setBounds(false, column, true);
+
+		this._pendingColumn = column;
+
+		if (!this._rafId) {
+			this._rafId = requestAnimationFrame(() => {
+				this._rafId = null;
+				if (this._pendingColumn) {
+					this.activeRange.setBounds(false, this._pendingColumn, true);
+					this._pendingColumn = null;
+				}
+			});
+		}
 	}
-	
-	///////////////////////////////////
+
 	//////// Cell Functionality ///////
 	///////////////////////////////////
 	
@@ -374,8 +392,18 @@ export default class SelectRange extends Module {
 		if (!this.mousedown || this.selecting === "all") {
 			return;
 		}
-		
-		this.activeRange.setBounds(false, cell, true);
+
+		this._pendingCell = cell;
+
+		if (!this._rafId) {
+			this._rafId = requestAnimationFrame(() => {
+				this._rafId = null;
+				if (this._pendingCell) {
+					this.activeRange.setBounds(false, this._pendingCell, true);
+					this._pendingCell = null;
+				}
+			});
+		}
 	}
 	
 	handleCellClick(e, cell){
@@ -900,7 +928,10 @@ export default class SelectRange extends Module {
 	}
 	
 	getTableRows() {
-		return this.table.rowManager.getDisplayRows().filter(row=> row.type === "row");
+		if (!this._tableRowsCache) {
+			this._tableRowsCache = this.table.rowManager.getDisplayRows().filter(row => row.type === "row");
+		}
+		return this._tableRowsCache;
 	}
 	
 	getTableColumns() {
@@ -924,6 +955,8 @@ export default class SelectRange extends Module {
 	}
 	
 	resetRanges() {
+		this._tableRowsCache = null;
+
 		var range, cell, visibleCells;
 		
 		this.ranges.forEach((range) => range.destroy());
@@ -949,6 +982,11 @@ export default class SelectRange extends Module {
 	tableDestroyed(){
 		document.removeEventListener("mouseup", this.mouseUpEvent);
 		this.table.rowManager.element.removeEventListener("keydown", this.keyDownEvent);
+		if (this._rafId) {
+			cancelAnimationFrame(this._rafId);
+			this._rafId = null;
+		}
+		this._tableRowsCache = null;
 	}
 	
 	selectedRows(component) {


### PR DESCRIPTION
Rectangular selection via mouse drag caused severe lag proportional to scroll position. At the bottom of a 50k-row table, each mousemove event triggered three O(n) operations making selection unusable.

Root causes and fixes:

1. RowManager.getRowFromPosition() used .find() scanning from index 0, reaching O(n) for rows near the bottom. Replaced with O(1) direct array access displayRows[position - 1] with .find() fallback for grouped-row edge cases.

2. SelectRange.getTableRows() created a new filtered array copy on every call. Added _tableRowsCache with invalidation in resetRanges() and tableDestroyed().

3. handleCellMouseMove / handleColumnMouseMove had no throttling, causing the full layout pipeline (getActiveCell -> getCell x 2 per range -> range.layout) to execute on every mouse event (~120/sec). Wrapped in requestAnimationFrame to cap at one layout per frame.