### PR TITLE
perf(frozencolumns): reinitialize rows in O(n)

### DIFF
--- a/src/js/modules/FrozenColumns/FrozenColumns.js
+++ b/src/js/modules/FrozenColumns/FrozenColumns.js
@@ -222,7 +222,8 @@ export default class FrozenColumns extends Module{
 	
 	reinitializeRows(){
 		var visibleRows = this.table.rowManager.getVisibleRows(true);
-		var otherRows = this.table.rowManager.getRows().filter(row => !visibleRows.includes(row));
+		var visibleRowSet = new Set(visibleRows);
+		var otherRows = this.table.rowManager.getRows().filter(row => !visibleRowSet.has(row));
 		
 		otherRows.forEach((row) =>{
 			row.deinitialize();

--- a/test/unit/modules/FrozenColumns.spec.js
+++ b/test/unit/modules/FrozenColumns.spec.js
@@ -351,6 +351,41 @@ describe('FrozenColumns', function(){
 			expect(result).toContain(rightCol2);
 		});
 
+		test('reinitializeRows deinitializes only non-visible rows and lays out visible ones', function(){
+			const frozenColumns = new FrozenColumns({});
+
+			const visible = [
+				{ type: "row", deinitialize: jest.fn() },
+				{ type: "row", deinitialize: jest.fn() },
+			];
+			const hidden = [
+				{ type: "row", deinitialize: jest.fn() },
+				{ type: "row", deinitialize: jest.fn() },
+			];
+			const allRows = [visible[0], hidden[0], visible[1], hidden[1]];
+
+			frozenColumns.table = {
+				rowManager: {
+					getVisibleRows: () => visible,
+					getRows: () => allRows,
+				},
+			};
+			frozenColumns.layoutRow = jest.fn();
+
+			frozenColumns.reinitializeRows();
+
+			// only the non-visible rows are deinitialized (Set-based exclusion)
+			expect(hidden[0].deinitialize).toHaveBeenCalledTimes(1);
+			expect(hidden[1].deinitialize).toHaveBeenCalledTimes(1);
+			expect(visible[0].deinitialize).not.toHaveBeenCalled();
+			expect(visible[1].deinitialize).not.toHaveBeenCalled();
+
+			// visible rows are laid out
+			expect(frozenColumns.layoutRow).toHaveBeenCalledTimes(2);
+			expect(frozenColumns.layoutRow).toHaveBeenCalledWith(visible[0]);
+			expect(frozenColumns.layoutRow).toHaveBeenCalledWith(visible[1]);
+		});
+
 		test('_calcSpace calculates width of columns', function(){
 			// Create a mock table
 			const mockTable = {};


### PR DESCRIPTION
### What
`FrozenColumns.reinitializeRows`: build a `Set` of the visible rows for the `otherRows` exclusion instead of `Array.includes` in a `filter` — O(rows × visible) → O(rows).

### Behaviour
Unchanged — adds a `reinitializeRows` test; full suite green.

### Performance (isolated, Node, 100k rows / 50 visible)
- `reinitializeRows` 2.17 → 1.44 ms (1.5×).

### Grid impact
Negligible — the saving (<1 ms) is a small fraction of a full redraw (~38 ms at 100k rows), within noise (headless Chromium, virtual renderer). Targeted micro-optimization that scales with rows × rendered-window. Baseline `upstream/master` @ `9539446`.
