### PR TITLE
Fix popup viewport positioning

### DIFF
--- a/src/js/core/tools/Popup.js
+++ b/src/js/core/tools/Popup.js
@@ -135,6 +135,10 @@ export default class Popup extends CoreFeature{
 		if(this.destroyed || this.table.destroyed){
 			return this;
 		}
+
+		if(!this.parent){
+			this.reversedX = false;
+		}
 		
 		if(origin instanceof HTMLElement){
 			parentEl = origin;
@@ -153,12 +157,11 @@ export default class Popup extends CoreFeature{
 			
 			x = coords.x;
 			y = coords.y;
-			
-			this.reversedX = false;
 		}
 		
 		this.element.style.top = y + "px";
 		this.element.style.left = x + "px";
+		this.element.style.right = "";
 		
 		this.container.appendChild(this.element);
 		
@@ -181,22 +184,35 @@ export default class Popup extends CoreFeature{
 	
 	_fitToScreen(x, y, parentEl, parentOffset, position){
 		var scrollTop = this.container === document.body ? document.documentElement.scrollTop : this.container.scrollTop;
+		var scrollLeft = this.container === document.body ? document.documentElement.scrollLeft : this.container.scrollLeft;
+		var boundsLeft = this.container === document.body ? scrollLeft : 0;
+		var boundsRight = this.container === document.body ? scrollLeft + document.documentElement.clientWidth : this.container.offsetWidth;
+		var offsetHeight = Math.max(this.container === document.body ? document.documentElement.clientHeight : this.container.offsetHeight, scrollTop ? this.container.scrollHeight : 0);
+		var newLeft = x;
 		
 		//move menu to start on right edge if it is too close to the edge of the screen
-		if((x + this.element.offsetWidth) >= this.container.offsetWidth || this.reversedX){
-			this.element.style.left = "";
-			
-			if(parentEl){
-				this.element.style.right = (this.container.offsetWidth - parentOffset.left) + "px";
+		if((newLeft + this.element.offsetWidth) > boundsRight || this.reversedX){
+			if(parentEl && position === "right"){
+				newLeft = parentOffset.left - this.element.offsetWidth;
+			}else if(parentEl && position === "left"){
+				newLeft = parentOffset.left + parentEl.offsetWidth;
+			}else if(parentEl){
+				newLeft = parentOffset.left - this.element.offsetWidth;
 			}else{
-				this.element.style.right = (this.container.offsetWidth - x) + "px";
+				newLeft = boundsRight - this.element.offsetWidth;
 			}
 			
 			this.reversedX = true;
 		}
+
+		if(newLeft < boundsLeft){
+			newLeft = boundsLeft;
+		}
+
+		this.element.style.left = newLeft + "px";
+		this.element.style.right = "";
 		
 		//move menu to start on bottom edge if it is too close to the edge of the screen
-		let offsetHeight = Math.max(this.container.offsetHeight, scrollTop ? this.container.scrollHeight : 0);
 		if((y + this.element.offsetHeight) > offsetHeight) {
 			if(parentEl){
 				switch(position){

--- a/test/unit/core/PopupTool.spec.js
+++ b/test/unit/core/PopupTool.spec.js
@@ -1,0 +1,141 @@
+import Popup from "../../../src/js/core/tools/Popup";
+
+describe("Popup tool", () => {
+    let popup;
+    let tableElement;
+    let popupElement;
+    let originalClientWidth;
+    let originalClientHeight;
+    let originalScrollLeft;
+    let originalScrollTop;
+    let originalBodyOffsetWidth;
+
+    function setReadonlyDimension(element, property, value) {
+        Object.defineProperty(element, property, {
+            configurable: true,
+            get: () => value,
+        });
+    }
+
+    beforeEach(() => {
+        originalClientWidth = Object.getOwnPropertyDescriptor(document.documentElement, "clientWidth");
+        originalClientHeight = Object.getOwnPropertyDescriptor(document.documentElement, "clientHeight");
+        originalScrollLeft = Object.getOwnPropertyDescriptor(document.documentElement, "scrollLeft");
+        originalScrollTop = Object.getOwnPropertyDescriptor(document.documentElement, "scrollTop");
+        originalBodyOffsetWidth = Object.getOwnPropertyDescriptor(document.body, "offsetWidth");
+
+        setReadonlyDimension(document.documentElement, "clientWidth", 650);
+        setReadonlyDimension(document.documentElement, "clientHeight", 600);
+        setReadonlyDimension(document.documentElement, "scrollLeft", 0);
+        setReadonlyDimension(document.documentElement, "scrollTop", 0);
+        setReadonlyDimension(document.body, "offsetWidth", 620);
+
+        tableElement = document.createElement("div");
+        document.body.appendChild(tableElement);
+
+        popupElement = document.createElement("div");
+        setReadonlyDimension(popupElement, "offsetWidth", 96);
+        setReadonlyDimension(popupElement, "offsetHeight", 200);
+
+        popup = new Popup({
+            destroyed: false,
+            element: tableElement,
+            options: {
+                popupContainer: false,
+            },
+            eventBus: {
+                subscribe: jest.fn(),
+                unsubscribe: jest.fn(),
+            },
+        }, popupElement);
+    });
+
+    afterEach(() => {
+        popupElement?.remove();
+        tableElement?.remove();
+
+        [
+            [document.documentElement, "clientWidth", originalClientWidth],
+            [document.documentElement, "clientHeight", originalClientHeight],
+            [document.documentElement, "scrollLeft", originalScrollLeft],
+            [document.documentElement, "scrollTop", originalScrollTop],
+            [document.body, "offsetWidth", originalBodyOffsetWidth],
+        ].forEach(([element, property, descriptor]) => {
+            if(descriptor){
+                Object.defineProperty(element, property, descriptor);
+            }else{
+                delete element[property];
+            }
+        });
+    });
+
+    it("positions body-hosted popups against the viewport instead of body width", () => {
+        popup.element.style.left = "554px";
+        popup.element.style.top = "202px";
+
+        popup._fitToScreen(554, 202, {offsetHeight: 34}, {left: 554}, "bottom");
+
+        expect(popup.element.style.left).toBe("554px");
+        expect(popup.element.style.right).toBe("");
+    });
+
+    it("positions body-hosted popups against the scrolled viewport", () => {
+        setReadonlyDimension(document.documentElement, "scrollLeft", 400);
+        popup.element.style.left = "554px";
+        popup.element.style.top = "202px";
+
+        popup._fitToScreen(554, 202, {offsetHeight: 34}, {left: 554}, "bottom");
+
+        expect(popup.element.style.left).toBe("554px");
+        expect(popup.element.style.right).toBe("");
+    });
+
+    it("reverses body-hosted popups with page coordinates when horizontally scrolled", () => {
+        setReadonlyDimension(document.documentElement, "clientWidth", 200);
+        setReadonlyDimension(document.documentElement, "scrollLeft", 400);
+        popup.element.style.left = "554px";
+        popup.element.style.top = "202px";
+
+        popup._fitToScreen(554, 202, {offsetHeight: 34}, {left: 554}, "bottom");
+
+        expect(popup.element.style.left).toBe("458px");
+        expect(popup.element.style.right).toBe("");
+    });
+
+    it("reverses child popups within container bounds", () => {
+        const container = document.createElement("div");
+        setReadonlyDimension(container, "offsetWidth", 650);
+        setReadonlyDimension(container, "offsetHeight", 600);
+        setReadonlyDimension(container, "scrollLeft", 0);
+        setReadonlyDimension(container, "scrollTop", 0);
+        setReadonlyDimension(popupElement, "offsetWidth", 100);
+        popup.container = container;
+        popup.element.style.left = "630px";
+        popup.element.style.top = "100px";
+
+        popup._fitToScreen(630, 100, {offsetWidth: 40, offsetHeight: 20}, {left: 610}, "right");
+
+        expect(popup.element.style.left).toBe("510px");
+        expect(popup.element.style.right).toBe("");
+        expect(popup.reversedX).toBe(true);
+    });
+
+    it("resets reversed positioning when a root popup is reused", () => {
+        const parentElement = document.createElement("div");
+        tableElement.appendChild(parentElement);
+        setReadonlyDimension(parentElement, "offsetWidth", 40);
+        setReadonlyDimension(parentElement, "offsetHeight", 20);
+        popup.elementPositionCoords = jest.fn(() => {
+            return {x: 200, y: 100, offset: {left: 200, top: 100}};
+        });
+        popup.subscribe = jest.fn();
+        popup.reversedX = true;
+        popup.element.style.right = "40px";
+
+        popup.show(parentElement, "bottom");
+
+        expect(popup.element.style.left).toBe("200px");
+        expect(popup.element.style.right).toBe("");
+        expect(popup.reversedX).toBe(false);
+    });
+});


### PR DESCRIPTION
Body-hosted popups were using `document.body.offsetWidth` as their horizontal boundary. When the body was narrower than the viewport, popups near the body edge could be treated as overflowing and repositioned incorrectly, even though they still fit within the visible viewport. The new bounds use viewport coordinates for body-hosted popups, including horizontal scroll offset, so page-coordinate popup positions are compared against the actual visible left/right edges.

Previously, overflow handling cleared `left` and set `right`. That worked for some overflow cases, but it could leave stale `right` positioning behind when the same popup element was reused. The new code normalizes horizontal placement back to an explicit `left` value and clears `right` on each show/fit pass.

The `reversedX` reset is limited to root popups. Child popups keep their reversal state so nested menus can continue opening consistently on the opposite side once they have had to reverse near an edge.




Closes #4285 (hopefully for good!). I don't have a enough understanding of the library to be confident that these changes don't cause problems elsewhere. They work well in my uses.

Before
<img width="640" height="300" alt="Screenshot 2026-07-05 at 13 31 20" src="https://github.com/user-attachments/assets/7740e67c-7736-4bc2-9626-5a191607340b" />
<img width="1459" height="409" alt="Screenshot 2026-07-05 at 13 31 59" src="https://github.com/user-attachments/assets/a8af43e7-3dcd-40f9-9c23-647bbb8a4435" />

After
<img width="625" height="258" alt="Screenshot 2026-07-05 at 13 29 44" src="https://github.com/user-attachments/assets/194bc12f-89a7-49bb-97bb-69cf991c6d59" />
<img width="1455" height="456" alt="Screenshot 2026-07-05 at 13 32 37" src="https://github.com/user-attachments/assets/33d958e8-989d-4ffc-af47-dea80df0954c" />
