### PR TITLE
fix(core): record renderMode as a string for custom renderer classes

### DIFF
--- a/src/js/core/RowManager.js
+++ b/src/js/core/RowManager.js
@@ -893,10 +893,19 @@ export default class RowManager extends CoreFeature{
 		}
 		
 		if(renderClass){
-			this.renderMode = this.table.options.renderVertical;
-			
 			this.renderer = new renderClass(this.table, this.element, this.tableElement);
 			this.renderer.initialize();
+
+			//renderMode must be a STRING: it is written into the
+			//tabulator-render-mode DOM attribute (see _showPlaceholder) and
+			//returned by getRenderMode(). options.renderVertical may be a custom
+			//renderer CLASS rather than a "virtual"/"basic" key; assigning it
+			//verbatim stringified the whole class source into the attribute.
+			//Prefer the resolved string key, else the renderer's own declared
+			//string renderMode, else fall back to "virtual".
+			this.renderMode = typeof this.table.options.renderVertical === "string"
+				? this.table.options.renderVertical
+				: (typeof this.renderer.renderMode === "string" ? this.renderer.renderMode : "virtual");
 			
 			if((this.table.element.clientHeight || this.table.options.height) && !(this.table.options.minHeight && this.table.options.maxHeight)){
 				this.fixedHeight = true;

--- a/test/unit/core/RowManager.spec.js
+++ b/test/unit/core/RowManager.spec.js
@@ -1,0 +1,62 @@
+import TabulatorFull from "../../../src/js/core/TabulatorFull";
+import VirtualDomVertical from "../../../src/js/core/rendering/renderers/VirtualDomVertical.js";
+
+// Regression: RowManager stored options.renderVertical verbatim in renderMode.
+// When a custom renderer CLASS was passed (renderVertical: SomeRenderer), the
+// class was later stringified into the tabulator-render-mode DOM attribute
+// (RowManager._showPlaceholder) and returned by getRenderMode() as a function
+// rather than a mode string.
+describe("RowManager renderMode", () => {
+	let el;
+
+	beforeEach(() => {
+		el = document.createElement("div");
+		document.body.appendChild(el);
+	});
+
+	afterEach(() => {
+		el.remove();
+	});
+
+	const build = (options) =>
+		new Promise((resolve) => {
+			const table = new TabulatorFull(el, options);
+			table.on("tableBuilt", () => resolve(table));
+		});
+
+	test("string renderVertical is recorded verbatim", async () => {
+		const table = await build({
+			renderVertical: "virtual",
+			placeholder: "No Data",
+			data: [],
+			columns: [{ title: "A", field: "a" }],
+		});
+
+		expect(table.rowManager.getRenderMode()).toBe("virtual");
+	});
+
+	test("custom renderer class resolves to a string mode, not the class source", async () => {
+		class CustomRenderer extends VirtualDomVertical {}
+
+		const table = await build({
+			renderVertical: CustomRenderer,
+			placeholder: "No Data",
+			data: [],
+			columns: [{ title: "A", field: "a" }],
+		});
+
+		const mode = table.rowManager.getRenderMode();
+		expect(typeof mode).toBe("string");
+		expect(mode).toBe("virtual");
+
+		// The mode is written into the tabulator-render-mode DOM attribute; before
+		// the fix this held the stringified class body. Show the placeholder so
+		// the attribute is actually written.
+		table.rowManager.tableEmpty();
+		const placeholder = table.element.querySelector("[tabulator-render-mode]");
+		expect(placeholder).not.toBeNull();
+		const attr = placeholder.getAttribute("tabulator-render-mode");
+		expect(attr).toBe("virtual");
+		expect(attr).not.toMatch(/class |function |=>/);
+	});
+});


### PR DESCRIPTION
### Problem

A custom renderer supplied as a class makes `renderMode` a constructor rather than a
string. `ResizeTable.js:43` gates on the literal `renderMode === "virtual"`, so that
comparison silently fails and table resizing stops working for custom renderers.

### Fix

Record `renderMode` as a string when a renderer class is supplied.

### Performance

Neutral, as intended. 500k rows, headless Chromium, K=5, medians:

| Metric | Before | After |
| --- | --- | --- |
| initial render (ms) | 97.6 | 101.5 |
| initial render, variable heights (ms) | 105.6 | 115.6 (sdPct 17.1) |
| fling churn, uniform | 14205 | 14205 |
| fling churn, variable | 3935 | 3935 |

Mutation churn is byte-identical, so the renderer does exactly the same work. The
render-ms spread is harness noise at this sample size.
