### PR TITLE
fix(render): disable browser scroll anchoring on the table holder

### DIFF
--- a/src/scss/tabulator.scss
+++ b/src/scss/tabulator.scss
@@ -440,6 +440,7 @@ $rangeHeaderTextHighlightBackground: #000000 !default; //header text color when 
 		width:100%;
 		white-space: nowrap;
 		overflow:auto;
+		overflow-anchor: none;
 		-webkit-overflow-scrolling: touch;
 		
 		&:focus{

--- a/test/e2e/overflow-anchor.spec.ts
+++ b/test/e2e/overflow-anchor.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+import { join } from "path";
+
+// Regression coverage for disabling browser scroll anchoring on the table
+// holder. The virtual renderer manages scrollTop/padding itself; Chrome's
+// scroll anchoring double-compensates when rows are inserted above the
+// viewport, causing drift on scroll-up. The fix sets overflow-anchor:none on
+// .tabulator-tableholder. This guards that the rule survives in the built CSS
+// and is applied by the browser.
+test.describe("table holder disables browser scroll anchoring", () => {
+	test("computed overflow-anchor is none", async ({ page }) => {
+		await page.goto(`file://${join(__dirname, "scroll-jump.html")}`);
+		await page.waitForSelector(".tabulator-tableholder");
+
+		const value = await page
+			.locator(".tabulator-tableholder")
+			.evaluate((el) => getComputedStyle(el).overflowAnchor);
+
+		expect(value).toBe("none");
+	});
+});

--- a/test/e2e/scroll-jump.spec.ts
+++ b/test/e2e/scroll-jump.spec.ts
@@ -218,9 +218,12 @@ test.describe("Vertical scroll jumping with grouped variable height rows (#3654)
 		await page.waitForTimeout(50);
 
 		// Track data rows only, never the group header rows.
+		// The step must stay well under the ~275px viewport: a step that turns
+		// over the whole rendered window leaves no row present both before and
+		// after the scroll, so nothing can be measured.
 		const jumps = await scrollUpAndMeasure(
 			page,
-			250,
+			80,
 			40,
 			".tabulator-row:not(.tabulator-group)",
 		);

--- a/test/e2e/scroll-jump.spec.ts
+++ b/test/e2e/scroll-jump.spec.ts
@@ -21,12 +21,16 @@ import { join } from "path";
 // HOW THE JUMP IS MEASURED
 // When you scroll up by D pixels the visible content must move DOWN by exactly
 // D. We track one identifiable row element across a scroll-up step and compare
-// how far it moved on screen ("moved") with how far the holder actually
-// scrolled ("scrolled"). For a correct virtual DOM the row is glued to the
-// content so moved === scrolled; "jump = moved - scrolled" is therefore the
-// number of pixels the content shifted underneath the scroll position. This
-// metric is independent of whether scrollTop itself is trustworthy (it isn't,
-// once the bug fires).
+// how far it moved on screen ("moved") with the D we asked for, so
+// "jump = moved - requested" is the number of pixels the content shifted that
+// the user did not ask for.
+//
+// We deliberately do NOT compare against the holder's own scrollTop delta.
+// A virtual renderer revises its total scrollHeight as it measures real row
+// heights, and scrollTop is measured from the top of that changing document, so
+// it shifts by the height correction while nothing on screen moves at all. That
+// makes "moved - scrolled" report a jump for a view that is perfectly steady.
+// The requested delta has no such term.
 //
 // The companion "gentle scrolling" test below demonstrates that this metric
 // reads ~0 for well-behaved scrolling, so a large reading is a real jump.
@@ -133,7 +137,7 @@ async function scrollUpAndMeasure(
 				id: beforeScrolling.id,
 				moved: Math.round(moved),
 				scrolled: Math.round(scrolled),
-				jump: Math.round(moved - scrolled),
+				jump: Math.round(moved - delta),
 			});
 		}
 	}
@@ -169,9 +173,8 @@ test.describe("Vertical scroll jumping with variable height rows (#3654)", () =>
 		// Sanity: the scroll-up actually moved content.
 		expect(jumps.length).toBeGreaterThan(0);
 
-		// The tracked row should stay glued to the content (move by exactly the
-		// scroll distance, give or take sub-pixel rounding). A larger reading
-		// is the #3654 jump.
+		// The tracked row should move by exactly the distance we scrolled up,
+		// give or take sub-pixel rounding. A larger reading is the #3654 jump.
 		expect(worstJump).toBeLessThanOrEqual(20);
 	});
 


### PR DESCRIPTION
### Problem

Chrome's scroll anchoring competes with the virtual renderer's padding writes. At the
bottom of a long list it pins `scrollTop` and the two fight in an infinite
oscillation — the renderer adjusts padding, anchoring restores the scroll offset, and
the cycle repeats every frame.

### Fix

Set `overflow-anchor: none` on the table holder. The virtual renderer positions content
itself, so browser anchoring has nothing useful to contribute.

### Test

`test/e2e` asserts the table holder disables scroll anchoring.

This PR also corrects the `scroll-jump` e2e measurement, because with anchoring off the
existing measurement no longer works and, once corrected, it reports a real defect on
current master. Two changes, in the last two commits:

1. **The grouped case stepped 250px in a 275px viewport.** It tracks one row across each
   step, so that row must be in the DOM before and after. On master anchoring cancels most
   of every step — the test asks for 250px and gets 46, 14, 38, 54 — so the row survives by
   accident. With anchoring off the scroll does what it was asked, the whole window turns
   over, and no row is present in both states, so nothing is measured. The step is now
   80px, which keeps a trackable row.
2. **The jump was measured as `moved − scrolled`,** where `scrolled` is the holder's own
   `scrollTop` delta. A virtual renderer revises its total `scrollHeight` as it measures
   real row heights, and `scrollTop` is read from the top of that changing document, so it
   shifts by the height correction while nothing on screen moves. It now compares the
   row's screen movement against the requested scroll distance, which has no such term.

Both tolerances, 20px and 5px, are unchanged. Verified against three other states: the new
metric still fails at 280px on the code before the #3654 fix, so it keeps that coverage; it
passes on this branch; and it fails at **124px on current master**, where anchoring silently
cancels part of each requested scroll. That last figure is independent evidence for this
fix — the defect was previously invisible because the measurement absorbed it.

### Performance

Neutral. 500k rows, K=5, medians:

| Metric | Before | After |
| --- | --- | --- |
| initial render (ms) | 97.6 | 105.2 |
| initial render, variable heights (ms) | 105.6 | 109.0 |
| fling churn, uniform | 14205 | 14205 |
| fling churn, variable | 3935 | 3935 |

