### PR TITLE
perf(render): clear the render area with replaceChildren()

### DIFF
--- a/src/js/core/rendering/renderers/BasicVertical.js
+++ b/src/js/core/rendering/renderers/BasicVertical.js
@@ -16,10 +16,10 @@ export default class BasicVertical extends Renderer{
 	
 	clearRows(){
 		var element = this.tableElement;
-		
-		// element.children.detach();
-		while(element.firstChild) element.removeChild(element.firstChild);
-		
+
+		//single native clear instead of N removeChild calls
+		element.replaceChildren();
+
 		element.scrollTop = 0;
 		element.scrollLeft = 0;
 		

--- a/src/js/core/rendering/renderers/VirtualDomVertical.js
+++ b/src/js/core/rendering/renderers/VirtualDomVertical.js
@@ -39,8 +39,8 @@ export default class VirtualDomVertical extends Renderer{
 	clearRows(){
 		var element = this.tableElement;
 
-		// element.children.detach();
-		while(element.firstChild) element.removeChild(element.firstChild);
+		//single native clear instead of N removeChild calls
+		element.replaceChildren();
 
 		element.style.paddingTop = "";
 		element.style.paddingBottom = "";
@@ -251,7 +251,7 @@ export default class VirtualDomVertical extends Renderer{
 		if(!position){
 			this.clear();
 		}else {
-			while(element.firstChild) element.removeChild(element.firstChild);
+			element.replaceChildren();
 
 			//check if position is too close to bottom of table
 			heightOccupied = (rowsCount - position + 1) * this.vDomRowHeight;

--- a/test/unit/core/VirtualDomVertical.clearRows.spec.js
+++ b/test/unit/core/VirtualDomVertical.clearRows.spec.js
@@ -1,0 +1,38 @@
+import TabulatorFull from "../../../src/js/core/TabulatorFull";
+
+// Guards that the replaceChildren() clear (replacing the removeChild loop) still
+// empties the render area.
+describe("VirtualDomVertical clearRows", () => {
+	let el;
+
+	beforeEach(() => {
+		el = document.createElement("div");
+		document.body.appendChild(el);
+	});
+
+	afterEach(() => {
+		el.remove();
+	});
+
+	test("clearRows removes all rendered row elements", async () => {
+		const table = await new Promise((resolve) => {
+			const t = new TabulatorFull(el, {
+				height: "200px",
+				data: Array.from({ length: 50 }, (_, i) => ({ id: i, a: "row " + i })),
+				columns: [{ title: "A", field: "a" }],
+			});
+			t.on("tableBuilt", () => resolve(t));
+		});
+
+		// jsdom does not lay out the virtual renderer, so seed the render area
+		// directly to prove clearRows empties it.
+		const tableElement = table.rowManager.tableElement;
+		tableElement.appendChild(document.createElement("div"));
+		tableElement.appendChild(document.createElement("div"));
+		expect(tableElement.children.length).toBe(2);
+
+		table.rowManager.renderer.clearRows();
+
+		expect(tableElement.children.length).toBe(0);
+	});
+});


### PR DESCRIPTION
### Change

Replace the three `while(element.firstChild) element.removeChild(element.firstChild)`
loops — in `VirtualDomVertical.clearRows`, `VirtualDomVertical._virtualRenderFill` and
`BasicVertical.clearRows` — with a single native `element.replaceChildren()`.

### Honest reporting of the measurement

**The benchmark tier cannot see this change.** Measured on its own build at 500k rows,
K=5, medians:

| `rerenderInPlace` metric | Before | After |
| --- | --- | --- |
| msFilter | 19.7 | 18.7 |
| nodesFilter | 60 | 60 |
| msClear | 11.0 | 11.4 (sdPct 15.7) |
| nodesClear | 80 | 80 |
| msReplace | 115.9 | 118.3 |
| nodesReplace | 160 | 160 |

The granular-scroll and tree-rerender scenarios are identical to master on every
counter (s1Churn 240, s1Nodes 48, s1Batches 24; nodesCollapse/nodesExpand 120/120).

The reason is that the `nodes` counter measures rows moved, and `replaceChildren()`
moves the same rows. The saving is in the number of native DOM **calls**, which no
counter in the harness reports, and `msClear` at 11.0 → 11.4 with 15.7% relative
standard deviation is noise in both directions.

So the claim rests on `test/unit/core/VirtualDomVertical.clearRows.spec.js` and on this
being strictly fewer native calls for the same result. It is a call-count and clarity
change, not a measurable speed-up. Draft because it is part of a larger renderer
series; happy for it to be judged on that basis alone.

### Note

The companion virtual-renderer rewrite PR in this series also uses `replaceChildren()`
in `VirtualDomVertical`, so expect a conflict there. Only the `BasicVertical.js` change
is unique to this PR.
