### PR TITLE
Fix editor focus loss and validation issues in Edit, SelectRange, and related modules

### DIFF
--- a/src/js/modules/ColumnCalcs/ColumnCalcs.js
+++ b/src/js/modules/ColumnCalcs/ColumnCalcs.js
@@ -27,6 +27,7 @@ export default class ColumnCalcs extends Module{
 		this.botRow = false;
 		this.topInitialized = false;
 		this.botInitialized = false;
+		this.topBreakElement = null; //structural <br> inserted alongside the top calc row
 		
 		this.blocked = false;
 		this.recalcAfterBlock = false;
@@ -253,6 +254,15 @@ export default class ColumnCalcs extends Module{
 		
 		if(this.topInitialized){
 			this.topInitialized = false;
+
+			//remove the structural <br> inserted alongside the calc row in
+			//initializeTopRow, otherwise it is orphaned and adds a blank line
+			//above the table on every group toggle
+			//https://github.com/tabulator-tables/tabulator/issues/4540
+			if(this.topBreakElement && this.topBreakElement.parentNode){
+				this.topBreakElement.parentNode.removeChild(this.topBreakElement);
+			}
+
 			this.topElement.parentNode.removeChild(this.topElement);
 			changed = true;
 		}
@@ -283,7 +293,12 @@ export default class ColumnCalcs extends Module{
 		
 		if(!this.topInitialized){
 
-			fragment.appendChild(document.createElement("br"));
+			//the headers and the calc row are both inline-block, the <br> forces
+			//the calc row onto its own line below the headers, removeCalcs
+			//removes it again by reference
+			this.topBreakElement = document.createElement("br");
+
+			fragment.appendChild(this.topBreakElement);
 			fragment.appendChild(this.topElement);
 
 			this.table.columnManager.getContentsElement().insertBefore(fragment, this.table.columnManager.headersElement.nextSibling);

--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -789,11 +789,20 @@ export default class Edit extends Module{
 						//trigger onRendered Callback
 						rendered();
 						
-						//prevent editing from triggering rowClick event
+						//prevent editing from triggering rowClick event and, with
+						//selectableRange, from starting a range selection whose focus
+						//transfer would blur and close the editor
+						//https://github.com/tabulator-tables/tabulator/issues/4563
 						var children = element.children;
-						
+
 						for (var i = 0; i < children.length; i++) {
 							children[i].addEventListener("click", function(e){
+								e.stopPropagation();
+							});
+							children[i].addEventListener("mousedown", function(e){
+								e.stopPropagation();
+							});
+							children[i].addEventListener("mouseup", function(e){
 								e.stopPropagation();
 							});
 						}

--- a/src/js/modules/Edit/Edit.js
+++ b/src/js/modules/Edit/Edit.js
@@ -38,6 +38,7 @@ export default class Edit extends Module{
 		
 		this.registerTableFunction("getEditedCells", this.getEditedCells.bind(this));
 		this.registerTableFunction("clearCellEdited", this.clearCellEdited.bind(this));
+		this.registerTableFunction("setCellEdited", this.setCellEdited.bind(this));
 		this.registerTableFunction("navigatePrev", this.navigatePrev.bind(this));
 		this.registerTableFunction("navigateNext", this.navigateNext.bind(this));
 		this.registerTableFunction("navigateLeft", this.navigateLeft.bind(this));
@@ -47,6 +48,7 @@ export default class Edit extends Module{
 		
 		this.registerComponentFunction("cell", "isEdited", this.cellIsEdited.bind(this));
 		this.registerComponentFunction("cell", "clearEdited", this.clearEdited.bind(this));
+		this.registerComponentFunction("cell", "setEdited", this.setEdited.bind(this));
 		this.registerComponentFunction("cell", "edit", this.editCell.bind(this));
 		this.registerComponentFunction("cell", "cancelEdit", this.cellCancelEdit.bind(this));
 		
@@ -176,6 +178,22 @@ export default class Edit extends Module{
 		
 		cells.forEach((cell) => {
 			this.table.modules.edit.clearEdited(cell._getSelf());
+		});
+	}
+	
+	//mark cells as edited programmatically, mirrors clearCellEdited
+	//https://github.com/tabulator-tables/tabulator/issues/4443
+	setCellEdited(cells){
+		if(!cells){
+			return;
+		}
+		
+		if(!Array.isArray(cells)){
+			cells = [cells];
+		}
+		
+		cells.forEach((cell) => {
+			this.table.modules.edit.setEdited(cell._getSelf());
 		});
 	}
 	
@@ -851,6 +869,24 @@ export default class Edit extends Module{
 		
 		if(editIndex > -1){
 			this.editedCells.splice(editIndex, 1);
+		}
+	}
+	
+	//mark a cell as edited without a user edit, mirrors clearEdited
+	//https://github.com/tabulator-tables/tabulator/issues/4443
+	setEdited(cell){
+		if(!cell.modules.edit){
+			cell.modules.edit = {};
+		}
+		
+		if(!cell.modules.edit.edited){
+			cell.modules.edit.edited = true;
+			
+			this.dispatch("edit-edited-set", cell);
+		}
+		
+		if(this.editedCells.indexOf(cell) == -1){
+			this.editedCells.push(cell);
 		}
 	}
 }

--- a/src/js/modules/ResizeColumns/ResizeColumns.js
+++ b/src/js/modules/ResizeColumns/ResizeColumns.js
@@ -174,7 +174,15 @@ export default class ResizeColumns extends Module{
 				handle.style.position = "sticky";
 				handle.style[column.modules.frozen.position] = this.frozenColumnOffset(column);
 			}
-			
+
+			//seed the handle with the row height, cell handles are recreated when
+			//a cell is re-rendered (e.g. after editing) and the cell-height event
+			//that usually sizes them does not fire again unless the height changes
+			//https://github.com/tabulator-tables/tabulator/issues/4544
+			if(type === "cell"){
+				handle.style.height = component.row.heightStyled;
+			}
+
 			config.handleEl = handle;
 			
 			if(element.parentNode && column.visible){

--- a/src/js/modules/Validate/defaults/validators.js
+++ b/src/js/modules/Validate/defaults/validators.js
@@ -125,22 +125,24 @@ export default {
 		if(value === "" || value === null || typeof value === "undefined"){
 			return true;
 		}
-		var unique = true;
+
+		//the "ignorecase" parameter enables case-insensitive comparison, other
+		//rows can hold non string values (numbers, empty cells), so only lower
+		//case when both sides are strings (https://github.com/tabulator-tables/tabulator/pull/4486)
+		var equals = parameters === "ignorecase"
+			? (x, y) => typeof x === "string" && typeof y === "string" ? x.toLowerCase() == y.toLowerCase() : x == y
+			: (x, y) => x == y;
 
 		var cellData = cell.getData();
 		var column = cell.getColumn()._getSelf();
 
-		this.table.rowManager.rows.forEach(function(row){
+		return !this.table.rowManager.rows.some(function(row){
 			var data = row.getData();
 
 			if(data !== cellData){
-				if(value == column.getFieldValue(data)){
-					unique = false;
-				}
+				return equals(value, column.getFieldValue(data));
 			}
 		});
-
-		return unique;
 	},
 
 	//must have a value

--- a/test/unit/modules/ColumnCalcsIntegration.spec.js
+++ b/test/unit/modules/ColumnCalcsIntegration.spec.js
@@ -1,0 +1,66 @@
+import TabulatorFull from "../../../src/js/core/TabulatorFull";
+
+// Integration tests for ColumnCalcs live in their own file because
+// ColumnCalcs.spec.js stubs Module.prototype globals at import time and does
+// not restore them, which would break a real TabulatorFull instance.
+
+describe("ColumnCalcs top calc row DOM structure", () => {
+    /** @type {TabulatorFull} */
+    let tabulator;
+
+    const brCount = () => tabulator.columnManager.getContentsElement().querySelectorAll("br").length;
+
+    beforeEach(async () => {
+        const el = document.createElement("div");
+        el.id = "column-calcs-integration";
+        document.body.appendChild(el);
+        tabulator = new TabulatorFull("#column-calcs-integration", {
+            data: [
+                { id: 1, name: "John", dept: "sales", value: 10 },
+                { id: 2, name: "Jane", dept: "sales", value: 20 },
+                { id: 3, name: "Bob", dept: "ops", value: 30 }
+            ],
+            columns: [
+                { title: "Name", field: "name" },
+                { title: "Dept", field: "dept" },
+                { title: "Value", field: "value", topCalc: "sum" }
+            ]
+        });
+
+        return new Promise((resolve) => {
+            tabulator.on("tableBuilt", () => {
+                resolve();
+            });
+        });
+    });
+
+    afterEach(() => {
+        tabulator.destroy();
+        document.getElementById("column-calcs-integration")?.remove();
+    });
+
+    // https://github.com/tabulator-tables/tabulator/issues/4540
+    it("should remove the calc row line break when grouping removes the calc row", () => {
+        // the calc row is inserted after the headers together with a structural
+        // <br> (other modules insert their own, so count relative to the start)
+        const initial = brCount();
+
+        // with the default columnCalcs setting, grouping moves the calcs into
+        // the groups and removes the table level calc row
+        tabulator.setGroupBy("dept");
+
+        expect(brCount()).toBe(initial - 1);
+    });
+
+    // https://github.com/tabulator-tables/tabulator/issues/4540
+    it("should not accumulate line breaks when grouping is toggled", () => {
+        const initial = brCount();
+
+        tabulator.setGroupBy("dept");
+        tabulator.setGroupBy(false);
+        tabulator.setGroupBy("dept");
+        tabulator.setGroupBy(false);
+
+        expect(brCount()).toBe(initial);
+    });
+});

--- a/test/unit/modules/Edit.spec.js
+++ b/test/unit/modules/Edit.spec.js
@@ -356,3 +356,76 @@ describe("Edit module - date editors with 'x' (epoch milliseconds) format", () =
 		expect(typeof cell.getValue()).toBe("number");
 	});
 });
+
+describe("Edit module programmatic edited state", () => {
+	let table;
+	
+	beforeEach(async () => {
+		document.body.innerHTML = '<div id="set-edited-table"></div>';
+		
+		table = new TabulatorFull("#set-edited-table", {
+			data: [
+				{ id: 1, name: "John" },
+				{ id: 2, name: "Jane" }
+			],
+			columns: [
+				{ title: "ID", field: "id" },
+				{ title: "Name", field: "name", editor: "input", validator: "required" }
+			]
+		});
+		
+		await new Promise(resolve => {
+			table.on("tableBuilt", resolve);
+		});
+	});
+	
+	afterEach(() => {
+		table.destroy();
+		document.body.innerHTML = "";
+	});
+	
+	// https://github.com/tabulator-tables/tabulator/issues/4443
+	it("should mark a cell as edited with cell.setEdited", () => {
+		const cell = table.getRows()[0].getCells()[1];
+		
+		expect(cell.isEdited()).toBe(false);
+		
+		cell.setEdited();
+		
+		expect(cell.isEdited()).toBe(true);
+		expect(table.getEditedCells().length).toBe(1);
+		expect(table.getEditedCells()[0].getField()).toBe("name");
+		
+		// marking twice must not duplicate the edited cell list entry
+		cell.setEdited();
+		expect(table.getEditedCells().length).toBe(1);
+		
+		// marking as edited must not run validation against an undefined value
+		expect(cell.getElement().classList.contains("tabulator-validation-fail")).toBe(false);
+		
+		// clearEdited mirrors setEdited
+		cell.clearEdited();
+		expect(cell.isEdited()).toBe(false);
+		expect(table.getEditedCells().length).toBe(0);
+	});
+	
+	// https://github.com/tabulator-tables/tabulator/issues/4443
+	it("should mark cells as edited with table.setCellEdited", () => {
+		const cellOne = table.getRows()[0].getCells()[1];
+		const cellTwo = table.getRows()[1].getCells()[1];
+		
+		table.setCellEdited([cellOne, cellTwo]);
+		
+		expect(cellOne.isEdited()).toBe(true);
+		expect(cellTwo.isEdited()).toBe(true);
+		expect(table.getEditedCells().length).toBe(2);
+		
+		table.clearCellEdited([cellOne, cellTwo]);
+		expect(table.getEditedCells().length).toBe(0);
+		
+		// a single cell component is accepted without an array wrapper
+		table.setCellEdited(cellOne);
+		expect(cellOne.isEdited()).toBe(true);
+		expect(table.getEditedCells().length).toBe(1);
+	});
+});

--- a/test/unit/modules/ResizeColumns.spec.js
+++ b/test/unit/modules/ResizeColumns.spec.js
@@ -146,3 +146,68 @@ describe("ResizeColumns module", () => {
         expect(mockColumn.setWidth).toHaveBeenCalledWith(120);
     });
 });
+
+describe("ResizeColumns cell handle height", () => {
+    /** @type {TabulatorFull} */
+    let tabulator;
+    let offsetSpies;
+
+    beforeAll(() => {
+        // jsdom computes no layout, so Tabulator's visibility check would skip
+        // rendering the table body and no cell resize handles would be created
+        offsetSpies = [
+            jest.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(30),
+            jest.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(100),
+        ];
+    });
+
+    afterAll(() => {
+        offsetSpies.forEach((spy) => spy.mockRestore());
+    });
+
+    beforeEach(async () => {
+        const el = document.createElement("div");
+        el.id = "resize-handle-test";
+        document.body.appendChild(el);
+        tabulator = new TabulatorFull("#resize-handle-test", {
+            data: [
+                { id: 1, name: "John" },
+                { id: 2, name: "Jane" }
+            ],
+            columns: [
+                { title: "ID", field: "id", resizable: true },
+                { title: "Name", field: "name", resizable: true, editor: "input" }
+            ],
+            renderVertical: "basic"
+        });
+
+        return new Promise((resolve) => {
+            tabulator.on("renderComplete", () => {
+                resolve();
+            });
+        });
+    });
+
+    afterEach(() => {
+        tabulator.destroy();
+        document.getElementById("resize-handle-test")?.remove();
+    });
+
+    // https://github.com/tabulator-tables/tabulator/issues/4544
+    it("should keep the handle height when a cell is re-rendered after an edit", () => {
+        const row = tabulator.rowManager.rows[0];
+        const cell = row.cells[1];
+
+        // jsdom computes no layout, so give the row its height through the API,
+        // which dispatches cell-height and sizes the existing handles
+        row.setHeight(42, true);
+
+        expect(cell.modules.resize.handleEl.style.height).toBe("42px");
+
+        // committing a new value re-renders the cell, which destroys and
+        // recreates the resize handle
+        cell.setValue("changed");
+
+        expect(cell.modules.resize.handleEl.style.height).toBe("42px");
+    });
+});

--- a/test/unit/modules/SelectRange.spec.js
+++ b/test/unit/modules/SelectRange.spec.js
@@ -146,3 +146,76 @@ describe("SelectRange module", () => {
         consoleWarnSpy.mockRestore();
     });
 });
+
+describe("SelectRange with cell editing", () => {
+    /** @type {TabulatorFull} */
+    let tabulator;
+    let offsetSpies;
+
+    beforeAll(() => {
+        // jsdom computes no layout, so Tabulator's visibility check would skip
+        // rendering the table body, leaving cells detached from the document,
+        // which would stop mouse events from bubbling to the table element and
+        // stop the editor input from receiving focus
+        offsetSpies = [
+            jest.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(30),
+            jest.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(100),
+        ];
+    });
+
+    afterAll(() => {
+        offsetSpies.forEach((spy) => spy.mockRestore());
+    });
+
+    beforeEach(async () => {
+        const el = document.createElement("div");
+        el.id = "select-range-edit-test";
+        document.body.appendChild(el);
+        tabulator = new TabulatorFull("#select-range-edit-test", {
+            data: [
+                { id: 1, name: "John", age: 30 },
+                { id: 2, name: "Jane", age: 25 }
+            ],
+            columns: [
+                { title: "ID", field: "id" },
+                { title: "Name", field: "name", editor: "input" },
+                { title: "Age", field: "age" }
+            ],
+            selectableRange: true,
+            renderVertical: "basic"
+        });
+
+        return new Promise((resolve) => {
+            tabulator.on("renderComplete", () => {
+                resolve();
+            });
+        });
+    });
+
+    afterEach(() => {
+        tabulator.destroy();
+        document.getElementById("select-range-edit-test")?.remove();
+    });
+
+    // https://github.com/tabulator-tables/tabulator/issues/4563
+    it("should keep the editor open when the editor input is clicked", () => {
+        const cell = tabulator.getRows()[0].getCells()[1];
+        const editMod = tabulator.module("edit");
+
+        cell.edit(true);
+        expect(editMod.currentCell).toBeTruthy();
+
+        const input = cell.getElement().querySelector("input");
+        expect(input).toBeTruthy();
+
+        // clicking inside the editor to place the caret must not start a range
+        // selection, the focus transfer that follows would blur and close the editor
+        input.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+        input.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+        input.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+        expect(editMod.currentCell).toBeTruthy();
+        expect(cell.getElement().classList.contains("tabulator-editing")).toBe(true);
+        expect(cell.getElement().querySelector("input")).toBeTruthy();
+    });
+});

--- a/test/unit/modules/SelectRange.spec.js
+++ b/test/unit/modules/SelectRange.spec.js
@@ -218,4 +218,21 @@ describe("SelectRange with cell editing", () => {
         expect(cell.getElement().classList.contains("tabulator-editing")).toBe(true);
         expect(cell.getElement().querySelector("input")).toBeTruthy();
     });
+
+    // https://github.com/tabulator-tables/tabulator/issues/4563
+    it("should still close the editor when another cell is pressed", () => {
+        const cell = tabulator.getRows()[0].getCells()[1];
+        const otherCell = tabulator.getRows()[1].getCells()[2];
+        const editMod = tabulator.module("edit");
+
+        cell.edit(true);
+        expect(editMod.currentCell).toBeTruthy();
+
+        // pressing outside the edited cell starts a new range selection, whose
+        // focus transfer blurs the editor input and commits the edit
+        otherCell.getElement().dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+
+        expect(editMod.currentCell).toBeFalsy();
+        expect(cell.getElement().querySelector("input")).toBeNull();
+    });
 });

--- a/test/unit/modules/Validate.spec.js
+++ b/test/unit/modules/Validate.spec.js
@@ -268,4 +268,36 @@ describe("Validate unique validator", () => {
         expect(result.map((cell) => cell.getValue()).sort()).toEqual(["STEVE", "Steve"]);
     });
 
+    // https://github.com/tabulator-tables/tabulator/pull/4486
+    it("should keep case sensitive comparison without the ignorecase parameter", async () => {
+        await buildTable(
+            [{ title: "Name", field: "name", validator: "unique" }],
+            [
+                { id: 1, name: "Steve" },
+                { id: 2, name: "STEVE" }
+            ]
+        );
+
+        expect(tabulator.validate()).toBe(true);
+    });
+
+    // https://github.com/tabulator-tables/tabulator/pull/4486
+    it("should not throw with the ignorecase parameter when the column holds non string values", async () => {
+        await buildTable(
+            [
+                { title: "Name", field: "name" },
+                { title: "Code", field: "code", validator: "unique:ignorecase" }
+            ],
+            [
+                { id: 1, name: "a", code: 10 },
+                { id: 2, name: "b", code: 20 },
+                { id: 3, name: "c" },
+                { id: 4, name: "d", code: null }
+            ]
+        );
+
+        let result;
+        expect(() => { result = tabulator.validate(); }).not.toThrow();
+        expect(result).toBe(true);
+    });
 });

--- a/test/unit/modules/Validate.spec.js
+++ b/test/unit/modules/Validate.spec.js
@@ -213,3 +213,59 @@ describe("Validate module", () => {
         expect(validateMod.getInvalidCells().length).toBe(0);
     });
 });
+
+describe("Validate unique validator", () => {
+    /** @type {TabulatorFull} */
+    let tabulator;
+    let offsetSpies;
+
+    beforeAll(() => {
+        // jsdom computes no layout, so Tabulator's visibility check would skip
+        // rendering the table body, rows would then have no cells and
+        // table.validate() would have nothing to check
+        offsetSpies = [
+            jest.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockReturnValue(30),
+            jest.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(100),
+        ];
+    });
+
+    afterAll(() => {
+        offsetSpies.forEach((spy) => spy.mockRestore());
+    });
+
+    const buildTable = async (columns, data) => {
+        const el = document.createElement("div");
+        el.id = "validate-unique-test";
+        document.body.appendChild(el);
+        tabulator = new TabulatorFull("#validate-unique-test", { data, columns, renderVertical: "basic" });
+
+        return new Promise((resolve) => {
+            tabulator.on("renderComplete", () => {
+                resolve();
+            });
+        });
+    };
+
+    afterEach(() => {
+        document.getElementById("validate-unique-test")?.remove();
+    });
+
+    // https://github.com/tabulator-tables/tabulator/pull/4486
+    it("should treat values differing only in case as duplicates with the ignorecase parameter", async () => {
+        await buildTable(
+            [{ title: "Name", field: "name", validator: "unique:ignorecase" }],
+            [
+                { id: 1, name: "Steve" },
+                { id: 2, name: "STEVE" },
+                { id: 3, name: "Jane" }
+            ]
+        );
+
+        const result = tabulator.validate();
+
+        expect(Array.isArray(result)).toBe(true);
+        expect(result.length).toBe(2);
+        expect(result.map((cell) => cell.getValue()).sort()).toEqual(["STEVE", "Steve"]);
+    });
+
+});


### PR DESCRIPTION
## Summary

This PR fixes several issues related to cell editing, range selection, validation, and DOM structure management across multiple modules. The changes ensure editors remain open when clicked, prevent unwanted range selections during editing, add programmatic edited state control, improve unique validator case-insensitivity, and fix DOM cleanup in column calculations.

The branch is structured for commit-by-commit review: the first commit adds 7 failing regression tests replicating all five issues, then each following commit fixes one issue and turns exactly its own tests green (7 failing → 6 → 4 → 3 → 1 → 0).

## Key Changes

### Edit Module (`src/js/modules/Edit/Edit.js`)
- Added `setCellEdited()` table function and `setEdited()` cell function to programmatically mark cells as edited without triggering validation on undefined values
- Added `stopPropagation()` for `mousedown` and `mouseup` events on editor children to prevent SelectRange from starting a range selection when the editor input is clicked
- This prevents focus transfer that would blur and close the editor

### Validate Module (`src/js/modules/Validate/defaults/validators.js`)
- Enhanced the `unique` validator to support an `ignorecase` parameter for case-insensitive comparison
- Safely handles non-string values (numbers, null) by only lowercasing when both values are strings
- Refactored to use `Array.some()` for cleaner logic

### ResizeColumns Module (`src/js/modules/ResizeColumns/ResizeColumns.js`)
- Fixed resize handle height loss when cells are re-rendered after editing
- Seeds the handle with the row's current height on creation, since the cell-height event doesn't fire again unless height changes

### ColumnCalcs Module (`src/js/modules/ColumnCalcs/ColumnCalcs.js`)
- Fixed orphaned `<br>` elements that accumulated when toggling grouping on/off
- Stores a reference to the structural `<br>` inserted with the top calc row and removes it when the calc row is removed
- Prevents blank lines from appearing above the table on repeated group toggles

## Tests Added

- **SelectRange with cell editing** – Verifies editor stays open when clicked and closes when another cell is pressed
- **Validate unique validator** – Tests case-insensitive comparison and non-string value handling
- **Edit module programmatic edited state** – Tests `setEdited()`, `clearEdited()`, and `setCellEdited()` APIs
- **ResizeColumns cell handle height** – Verifies handle height is preserved after cell re-render
- **ColumnCalcs top calc row DOM structure** – Tests `<br>` cleanup on grouping toggle

All integration tests use `TabulatorFull` with jsdom layout mocking via `offsetHeight`/`offsetWidth` spies to enable proper rendering and event handling (Tabulator skips rendering the table body when `Helpers.elVisible` fails, which it always does under jsdom's zero layout).

## Closes

Merging this PR closes the following issues:

- Closes #4443 (programmatic edited state: `cell.setEdited` / `table.setCellEdited`)
- Closes #4540 (orphaned `<br>` adds space between headers and rows with topCalc + grouping)
- Closes #4544 (column resize handle disappears after editing a cell)

Related: #4563 (already closed) — this PR fixes its remaining symptom, clicking the editor input closing the editor when `selectableRange` is enabled.

## Supersedes

The following 2024 PRs are superseded by this branch and can be closed once this merges (closing keywords don't auto-close PRs):

- #4485 — setEdited: reimplemented; the original only set the flag when it was already set, never registered the `setCellEdited` table function, and reused the `edit-success` validation event
- #4486 — unique ignorecase: adopted, hardened against non-string values in other rows
- #4550 — resize handle height: adopted, with an explicit `type === "cell"` guard instead of optional chaining
- #4551 — calc row `<br>`: same diagnosis, removed by stored reference instead of `previousSibling`
- #4621 — editor mousedown/mouseup propagation: adopted as proposed, plus regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ptNPAYXPdD7Tnwn1whcb9